### PR TITLE
Added types in params

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -228,7 +228,7 @@ app.get("/fruits/search", (req: Denoot.Request, res: Denoot.Response)) => {
     ); // Will output: You searched for: "apples" and sorted desc
 });
 ```
-**Note:** it's possible to set query using `Request.params.set(key: string, value: string)` however this is not recommended and is considered bad practice. Instead define custom properties on `Request`.
+**Note:** it's possible to set query using `Request.query.set(key: string, value: string)` however this is not recommended and is considered bad practice. Instead define custom properties on `Request`.
 
 
 ## Cookies
@@ -374,7 +374,7 @@ app.get("/posts/all", (req: Denoot.Request, res: Denoot.Response)) => {
 
 // This route will not be reached! Since res.end() was called earlier
 app.get("/posts/{postID}", (req: Denoot.Request, res: Denoot.Response)) => {
-    res.send(posts[ req.params.get("postID") ]);
+    res.send(posts[ req.params.get("postID").parsed ]);
 });
 ```
 **Note:** If you have a lot of routes or very expensive routes/middleware it's considered best practice to use `res.end()` to prevent Denoot from checking further routes. 
@@ -426,7 +426,7 @@ app.render(handle.renderView.bind(handle));
 app.get("/user/{username}", async (req: Denoot.Request, res: Denoot.Response) => {
     // assumes ./views/user.hbs and ./views/layouts.main.hbs exists. See https://deno.land/x/handlebars
     await res.render("user", {
-        firstname: req.params.get("username"),
+        firstname: req.params.get("username").parsed,
         lastname: "Doe"
     });
 });

--- a/readme.md
+++ b/readme.md
@@ -188,6 +188,25 @@ app.map("get", "put", "patch")("/path", callback);
 
 
 Denoot organizes url parameters as a `Map<string, Param>` in `req.params`. If you prefer Object instead you can use the readonly property `req.objectParams`
+
+```
+app.get("/users/{userID: number}", (req: Denoot.Request, res: Denoot.Response)) => {
+    if(req.params.get("userID").error) {
+        // Oh no! userID couldn't be parsed
+        return res.send("That's not a valid user id");
+    }
+
+    res.send("User ID: " + req.params.get("userID").parsed);
+});
+```
+If you don't want to define a type opt-out of writing a type, Denoot will assume the param is of type string
+```ts
+app.get("/users/{name}", (req: Denoot.Request, res: Denoot.Response)) => {
+    res.send("Your name is of type: " + req.params.get("userID").type); // Will be string
+});
+```
+
+The `Param` type looks like this:
 ```ts
 interface Param {
     name: string, // name of param
@@ -196,24 +215,9 @@ interface Param {
     parsed: number | string | null, // parsed input
     error: boolean  // boolean to show if there was a parsing error
 }
-
-app.get("/users/{userID: number}", (req: Denoot.Request, res: Denoot.Response)) => {
-    if(req.params.get("userID").error´) {
-        // Oh no userID couldn't be parsed
-        return res.send("That's not a valid user id");
-    }
-
-    res.send("User ID: " + req.params.get("userID").parsed);
-});
-```
-If you don't want to define a type opt-out of writing a type, denoot will assume the param is of type string
-```ts
-app.get("/users/{name}", (req: Denoot.Request, res: Denoot.Response)) => {
-    res.send("Your name is of type: " + req.params.get("userID").type); // Will be string
-});
 ```
 
-**Note:** it's possible to set params using `req.params.set(key: string, value: Param)` however this is not recommended and is considered bad practice. Instead define custom properties on `Request`.
+**Note:** it's possible to set params using `req.params.set(key: string, value: Param)` however this is not recommended and is considered bad practice. Instead set custom variables using `req.variables.set("name", "value")`.
 
 ## URL Search Query
 [⬆️ Table of Contents ⬆️](#table-of-contents)

--- a/src/classes/DenootRequest.ts
+++ b/src/classes/DenootRequest.ts
@@ -1,5 +1,5 @@
 import { ServerRequest } from "https://deno.land/std@0.85.0/http/server.ts";
-import { AllMethods, RenderEngineCallback } from "../../types/definitions.d.ts";
+import { AllMethods, RenderEngineCallback, Param } from "../../types/definitions.d.ts";
 import { State } from "../../mod.ts";
 import { parseCookies } from "../cookieParser/cookieParser.ts";
 import { decode } from "https://deno.land/std@0.85.0/encoding/utf8.ts";
@@ -13,7 +13,7 @@ class DenootRequest {
 
     private _url: string = "";
     private _method: AllMethods;
-    private _params: Map<string, string> = new Map();
+    private _params: Map<string, Param> = new Map();
     private _query: Map<string, string> = new Map();
     private _variables: Map<string, any> = new Map();
     private _headers: Headers;

--- a/src/routing/routes.ts
+++ b/src/routing/routes.ts
@@ -46,7 +46,7 @@ export const createParts = (path: string) => {
 }
 
 export const extractVariable = (part: string): ({ name: string, type: AllowedParameterTypes } | null) => {
-    // First check to se if there's a : in the varible.
+    // First check to se if there's a : in the variable.
     const isTypeVariable = part.match(/(?<=({.*))(:)(?=(.*}))/);
     const paramTypes: AllowedParameterTypes[] = ["string", "number", "any", "int"];
 
@@ -81,8 +81,8 @@ const createPath = (path: string): RoutePath => {
     if (!path.startsWith("/")) {
         throw new Error("Path must begin with forward slash (/)");
     }
-    // Since args can include {myVar: numver} and white space is allowed there
-    // We remvoe all occurences of those first
+    // Since args can include {myVar: number} and white space is allowed there
+    // We remove all occurrences of those first
     else if (path.replace(/(?<=({.*))\s*:\s*(?=(.*}))/, "").match(/\s/)) {
         throw new Error("Path cannot include white space. If you must have white space URI encode the path");
     }
@@ -97,8 +97,6 @@ const createPath = (path: string): RoutePath => {
 
             return {
                 part,
-                // a nullish coalescing expression does not work as a
-                // type guard here. https://stackoverflow.com/a/61233021/13188385
                 variable: extractedVariable
             }
         })

--- a/src/routing/routes.ts
+++ b/src/routing/routes.ts
@@ -1,5 +1,5 @@
 import { declareStackItem } from "../stack.ts";
-import { AllMethods, RouteCallback, DeclarePath, RoutePath, DeclareRouteOptions, DeclareRoute, Methods, MethodsLowerCase } from "../../types/definitions.d.ts";
+import { AllMethods, RouteCallback, DeclarePath, RoutePath, DeclareRouteOptions, DeclareRoute, Methods, MethodsLowerCase, AllowedParameterTypes } from "../../types/definitions.d.ts";
 
 import { State } from "../../mod.ts";
 
@@ -25,7 +25,6 @@ export const trailingSlash = (path: string): boolean => {
 export const trailingWildcard = (path: string): boolean => {
 
     return !!path.match(/\*$/)?.[0]
-
 }
 
 export const createParts = (path: string) => {
@@ -37,7 +36,8 @@ export const createParts = (path: string) => {
     const parsedPathName = url
         .pathname
         .replace(/%7B/g, "{")
-        .replace(/%7D/g, "}");
+        .replace(/%7D/g, "}")
+        .replace(/%20/g, " ");
 
     const parsedPath = serializePath(parsedPathName);
 
@@ -45,10 +45,35 @@ export const createParts = (path: string) => {
 
 }
 
-export const extractVariable = (part: string) => {
+export const extractVariable = (part: string): ({ name: string, type: AllowedParameterTypes } | null) => {
+    // First check to se if there's a : in the varible.
+    const isTypeVariable = part.match(/(?<=({.*))(:)(?=(.*}))/);
+    const paramTypes: AllowedParameterTypes[] = ["string", "number", "any", "int"];
 
-    return part.match(/(?<={)(.*)(?=})/gm);
+    if (isTypeVariable) {
+        // Since isTypeVariable guarantees a match we can cast this to any,
+        const varName: string = (part.match(/(?<={)(.*)(?=(:.*}))/gm) as any)[0].trim();
+        const varType: string = (part.match(/(?<=({.*:))(.*)(?=})/gm) as any)[0].trim();
 
+        if (!(paramTypes as any).includes(varType)) {
+            throw new Error(`Type ${varType} is not a valid parameter type`);
+        }
+
+        return {
+            name: varName,
+            type: varType as AllowedParameterTypes
+        }
+    } else {
+        const varName = part.match(/(?<={)(.*)(?=})/gm);
+
+        if (varName === null)
+            return null
+
+        return {
+            name: varName[0],
+            type: "string"
+        };
+    }
 }
 
 const createPath = (path: string): RoutePath => {
@@ -56,7 +81,9 @@ const createPath = (path: string): RoutePath => {
     if (!path.startsWith("/")) {
         throw new Error("Path must begin with forward slash (/)");
     }
-    else if (path.match(/\s/)) {
+    // Since args can include {myVar: numver} and white space is allowed there
+    // We remvoe all occurences of those first
+    else if (path.replace(/(?<=({.*))\s*:\s*(?=(.*}))/, "").match(/\s/)) {
         throw new Error("Path cannot include white space. If you must have white space URI encode the path");
     }
 
@@ -72,9 +99,7 @@ const createPath = (path: string): RoutePath => {
                 part,
                 // a nullish coalescing expression does not work as a
                 // type guard here. https://stackoverflow.com/a/61233021/13188385
-                variable: extractedVariable !== null ? {
-                    name: extractedVariable[0]
-                } : null
+                variable: extractedVariable
             }
         })
     }
@@ -120,6 +145,6 @@ export const any = (state: State) => addRoute(state, ["_ALL"]);
 
 export const map = (state: State) =>
     (...methods: (Methods | MethodsLowerCase)[]) =>
-    addRoute(state, methods.map(method => method.toUpperCase()) as Methods[]);
+        addRoute(state, methods.map(method => method.toUpperCase()) as Methods[]);
 
 export const use = (state: State) => addRoute(state, ["_ALL"], { middleware: true });

--- a/src/stack.ts
+++ b/src/stack.ts
@@ -1,5 +1,5 @@
 import * as HTTP from "https://deno.land/std@0.85.0/http/server.ts";
-import { Response, Request, RouteStackItem, AllMethods, RoutePath, RouteCallback, DeclareRouteOptions, AllMethod, RouteBaseCallback } from "../types/definitions.d.ts";
+import { Response, Request, RouteStackItem, AllMethods, RoutePath, RouteCallback, DeclareRouteOptions, AllMethod, RouteBaseCallback, Param, AllowedParameterTypes } from "../types/definitions.d.ts";
 import { createParts } from "./routing/routes.ts";
 import DenootResponse from "./classes/DenootResponse.ts";
 import DenootRequest from "./classes/DenootRequest.ts";
@@ -70,7 +70,43 @@ const matchRequestWithRoute = (req: Request, route: RouteStackItem) => {
         if (isWildcard(declaredPart.part)) return true;
 
         if (declaredPart.variable && incomingPart) {
-            req.params.set(declaredPart.variable.name, incomingPart);
+            const incomingParameter: Param = {
+                name: declaredPart.variable.name,
+                type: declaredPart.variable.type as AllowedParameterTypes,
+                raw: incomingPart,
+                parsed: null,
+                error: false
+            };
+
+            // type checking for varibles
+            switch (declaredPart.variable.type) {
+                case "any":
+                    incomingParameter.parsed = incomingPart;
+                    break;
+                case "string":
+                    incomingParameter.parsed = incomingPart;
+                    break;
+                case "number":
+                    const parsedNumber = parseFloat(incomingPart);
+                    if (isNaN(parsedNumber)) {
+                        incomingParameter.error = true;
+                    } else {
+                        incomingParameter.parsed = parsedNumber;
+                    }
+                    break;
+                case "int":
+                    const parsedInt = parseInt(incomingPart);
+                    if (isNaN(parsedInt)) {
+                        incomingParameter.error = true;
+                    } else {
+                        incomingParameter.parsed = parsedInt;
+                    }
+                    break;
+            }
+
+
+            req.params.set(declaredPart.variable.name, incomingParameter);
+
             continue matchDeclaredPathParts;
         }
         else if (declaredPart.part === incomingPart)

--- a/src/stack.ts
+++ b/src/stack.ts
@@ -78,7 +78,7 @@ const matchRequestWithRoute = (req: Request, route: RouteStackItem) => {
                 error: false
             };
 
-            // type checking for varibles
+            // type checking for URL parameter
             switch (declaredPart.variable.type) {
                 case "any":
                     incomingParameter.parsed = incomingPart;

--- a/types/definitions.d.ts
+++ b/types/definitions.d.ts
@@ -20,6 +20,7 @@ export type DeclareRoute = ((path: DeclarePath | RouteCallback, callback?: Route
 export type RenderEngineCallback = (filePath: string, options: any) => string | Promise<string>;
 export type RenderEngine = (renderCallback: RenderEngineCallback) => unknown;
 export type StaticCallback = (route: DeclarePath, options: StaticRouteOptions) => unknown;
+export type AllowedParameterTypes = "string" | "number" | "any" | "int";
 
 export interface StaticRouteBaseOptions {
     index: string;
@@ -32,12 +33,21 @@ export interface StaticRouteOptions {
     autoIndex?: boolean;
 }
 
+export interface Param {
+    name: string,
+    type: AllowedParameterTypes,
+    raw: string,
+    parsed: number | string | null,
+    error: boolean
+}
+
 export interface RoutePath {
     original: string;
     params: {
         part: string;
         variable: null | {
-            name: string;
+            name: string,
+            type: string
         }
     }[]
 }


### PR DESCRIPTION
Possibility to add types to paramater
```ts
app.get("/user/{userID: number}", (req, res) => {
    const { parsed, error } = req.params.get("userID"); // Parsed to a Float
    if(error) {
        // Couldn't parse to float
    }
    res.send(parsed + 1);
});
```
If no type was specified type "string" is assumed
```ts
app.get("/submit-name/{name}", (req, res) => {
    const { type } = req.params.get("name");
    console.log(type); // will be string
});
```